### PR TITLE
added .env credetials for all AWS clients.

### DIFF
--- a/server/aws/clients/iamClient.mjs
+++ b/server/aws/clients/iamClient.mjs
@@ -1,7 +1,11 @@
 import { IAMClient } from '@aws-sdk/client-iam';
 
 const iamClient = new IAMClient({ 
-  region: process.env.AWS_REGION
+  region: process.env.AWS_REGION,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY,
+    secretAccessKey: process.env.AWS_SECRET_KEY
+  }
 });
 
 export default iamClient;

--- a/server/aws/clients/lambdaClient.mjs
+++ b/server/aws/clients/lambdaClient.mjs
@@ -1,6 +1,11 @@
 import { LambdaClient } from '@aws-sdk/client-lambda';
 
 const lambdaClient = new LambdaClient({ 
-  region: process.env.AWS_REGION
+  region: process.env.AWS_REGION,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY,
+    secretAccessKey: process.env.AWS_SECRET_KEY
+  }
 });
+
 export default lambdaClient;

--- a/server/aws/clients/s3Client.mjs
+++ b/server/aws/clients/s3Client.mjs
@@ -1,4 +1,5 @@
 import { S3Client } from '@aws-sdk/client-s3';
+
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -10,4 +11,5 @@ const s3Client = new S3Client({
     secretAccessKey: process.env.AWS_SECRET_KEY
   }
 });
+
 export default s3Client;

--- a/server/aws/clients/sqsClient.mjs
+++ b/server/aws/clients/sqsClient.mjs
@@ -1,4 +1,5 @@
 import { SQSClient } from '@aws-sdk/client-sqs';
+
 import dotenv from 'dotenv';
 
 dotenv.config();


### PR DESCRIPTION
Changes Made:

- Added AWS key information for each AWS client 

**Tested ```deploy``` and ```destroy``` scripts.
**Tested application logic. --> able to use dynamically created AWS infa. to hit logstash endpoint

Notes:
```dotenv``` had to stay in ```sqsClient``` and ```s3Client``` , the ```.env``` credentials were not available at application runtime despite being imported at the top level of the application.